### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 
 gem 'kramdown-parser-gfm'
 gem 'webrick'
+
+gem 'rake', '12.3.3'
+gem 'jekyll-paginate-v2', '2.0.0'
+gem 'sassc'


### PR DESCRIPTION
Encountering an error when trying to serve a Jekyll site using Bundler. The specific error message is:

Could not find rake-12.3.3, jekyll-paginate-v2-2.0.0 in locally installed gems (Bundler::GemNotFound)

This means that the specified versions of rake and jekyll-paginate-v2 gems are not installed in the current environment.

Fix:
1. Install Missing Gems
2. Update Ruby Sass